### PR TITLE
Support FCM token deletion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ keywords = ["push", "fcm"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["ring"]
+ring = ["rustls/ring"]
+aws-lc-rs = ["rustls/aws-lc-rs"]
+
 [dependencies]
 base64 = "0.22"
 bytes = "1.10"
@@ -18,7 +23,7 @@ pin-project-lite = "0.2.16"
 prost = "0.13.5"
 rand = "0.9"
 reqwest = { version = "0.12", features = ["json"] }
-rustls = { version = "0.23", features = ["ring"] }
+rustls = "0.23"
 serde = "1.0"
 serde_with = "3.12"
 tokio = { version = "1", default-features = false, features = [

--- a/src/bin/demo.rs
+++ b/src/bin/demo.rs
@@ -1,5 +1,7 @@
 pub use fcm_push_listener::Error;
-use fcm_push_listener::{new_heartbeat_ack, MessageStream, Registration, Session as GcmSession, WebPushKeys};
+use fcm_push_listener::{
+    new_heartbeat_ack, MessageStream, Registration, Session as GcmSession, WebPushKeys,
+};
 use tokio::io::AsyncWriteExt;
 
 async fn run(registration: Registration) -> Result<(), fcm_push_listener::Error> {

--- a/src/fcm.rs
+++ b/src/fcm.rs
@@ -1,5 +1,6 @@
 use crate::Error;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 fn to_base64<S: serde::ser::Serializer>(v: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
     use base64::Engine;
@@ -71,6 +72,34 @@ impl Registration {
             fcm_token: response.token,
             keys: push_keys,
         })
+    }
+
+    pub async fn unregister_request(
+        http: &reqwest::Client,
+        project_id: &str,
+        api_key: &str,
+        firebase_installation_auth_token: &str,
+        fcm_token: &str,
+    ) -> Result<(), Error> {
+        const FCM_REGISTRATION_API: &str = "https://fcmregistrations.googleapis.com/v1";
+
+        const API_NAME: &str = "FCM Registration";
+        const API_KEY_HEADER: &str = "x-goog-api-key";
+        const AUTH_HEADER: &str = "x-goog-firebase-installations-auth";
+
+        let url = format!("{FCM_REGISTRATION_API}/projects/{project_id}/registrations/{fcm_token}");
+        http.delete(url)
+            .header(API_KEY_HEADER, api_key)
+            .header(AUTH_HEADER, firebase_installation_auth_token)
+            .send()
+            .await
+            .map_err(|e| Error::Request(API_NAME, e))?
+            .error_for_status()
+            .map_err(|e| Error::Request(API_NAME, e))?
+            .json::<HashMap<(), ()>>()
+            .await
+            .map_err(|e| Error::Response(API_NAME, e))
+            .map(drop)
     }
 }
 

--- a/src/gcm.rs
+++ b/src/gcm.rs
@@ -223,6 +223,9 @@ impl CheckedSession {
 
         // Install the default crypto provider. If a different one is already registered, this
         // will do nothing.
+        #[cfg(feature = "aws-lc-rs")]
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        #[cfg(feature = "ring")]
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         const ERR_RESOLVE: Error =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@ mod mcs {
 }
 
 mod error;
-mod fcm;
-mod firebase;
+pub mod fcm;
+pub mod firebase;
 mod gcm;
 mod push;
 mod register;


### PR DESCRIPTION
I use `fcm-push-listener` in my E2E tests and missing the token deletion functionality.

This PR:
- provides `fcm::Registration::unregister_request` which implements HTTP request deleting the provided FCM token (according to [js-sdk](https://github.com/firebase/firebase-js-sdk/blob/d818df4e8697c70bf9dbf58620e47d40d175ecc8/packages/messaging/src/internals/requests.ts#L119));
- makes `fcm` and `firebase` modules `pub` allowing end-users to implement their own `Registration`/`register` (to store additional data such as _Firebase installation token_);
- provides `ring` and `aws-lc-rs` Cargo features (with default `ring` feature for backward-compat) to avoid mixing crypto providers in end-user application (my crate uses `aws-lc-rs` by default and it conflicts with `fcm-push-listener` which uses `ring`).